### PR TITLE
Add env vars VNCGROUP, VNCGID, VNCUMASK and make container restartable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Default: same as VNCUSER and VNCUID
 -e VNCGROUP='guests' -e VNCGID='1001'
 ```
 
+Optional: Set umask to define permission for new files \
+Default: 022
+```
+-e VNCUMASK='0002'
+```
+
 ## TimeZone Configuration
 Set the timezone to be used inside the container \
 Default: UTC

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Default: root (UID: 0)
 -e VNCUSER='guest' -e VNCUID='1000'
 ```
 
+Optional: Set a custom group for non-root user \
+Default: same as VNCUSER and VNCUID
+```
+-e VNCGROUP='guests' -e VNCGID='1001'
+```
+
 ## TimeZone Configuration
 Set the timezone to be used inside the container \
 Default: UTC
@@ -71,6 +77,10 @@ docker run -d -p 127.0.0.1:5901:5901 -e VNCPASS='vncpass' -e VNCPASSRO='readonly
 Run the image as a non-root user account
 ```
 docker run -d -p 127.0.0.1:5901:5901 -e VNCUSER='guest' -e VNCUID='1000' fullaxx/ubuntu-desktop
+```
+Run the image as a non-root user account with custom groud
+```
+docker run -d -p 127.0.0.1:5901:5901 -e VNCUSER='guest' -e VNCUID='1000' -e VNCGROUP='guests' -e VNCGID='1001' fullaxx/ubuntu-desktop
 ```
 Run the image in Tokyo
 ```

--- a/app/imagestart.sh
+++ b/app/imagestart.sh
@@ -13,8 +13,17 @@ rm -f /tmp/.X11-unix/*
 /etc/init.d/dbus start
 
 if [ -n "${VNCUSER}" ] && [ -n "${VNCUID}" ]; then
-  useradd -u ${VNCUID} -G sudo -s /bin/bash -m -d /home/${VNCUSER} ${VNCUSER}
+  # Check if VNCGROUP and VNCGID are set or set to VNCUSER and VNCUID
+  if [ -z "${VNCGROUP}" ]; then
+    VNCGROUP=${VNCUSER}
+  fi
+  if [ -z "${VNCGID}" ]; then
+    VNCGID=${VNCUID}
+  fi
+  groupadd -g ${VNCGID} ${VNCGROUP}
+  useradd -u ${VNCUID} -g ${VNCGID} -G sudo -s /bin/bash -m -d /home/${VNCUSER} ${VNCUSER}
   export USER="${VNCUSER}"
+  export GROUP="${VNCGROUP}"
   if [ -n "${ACCTPASS}" ]; then
     echo "${VNCUSER}:${ACCTPASS}" | chpasswd
     unset ACCTPASS

--- a/app/imagestart.sh
+++ b/app/imagestart.sh
@@ -22,6 +22,10 @@ if [ -n "${VNCUSER}" ] && [ -n "${VNCUID}" ]; then
   fi
   groupadd -g ${VNCGID} ${VNCGROUP}
   useradd -u ${VNCUID} -g ${VNCGID} -G sudo -s /bin/bash -m -d /home/${VNCUSER} ${VNCUSER}
+
+  if [ -n ${VNCUMASK} ]; then
+    echo "umask ${VNCUMASK}" >> /home/${VNCUSER}/.bashrc
+  fi
   export USER="${VNCUSER}"
   export GROUP="${VNCGROUP}"
   if [ -n "${ACCTPASS}" ]; then

--- a/app/imagestart.sh
+++ b/app/imagestart.sh
@@ -3,6 +3,10 @@
 # sudo configuration for ubuntu-desktop
 install -m 0440 /usr/share/ubuntu-desktop/sudo /etc/sudoers.d/ubuntudesktop
 
+# Delete old temp files in case the images was restarted
+rm -f /tmp/.X*-lock
+rm -f /tmp/.X11-unix/*
+
 # Necessary for many applications
 # (i.e. Chrome, terminator, ktorrent, ...)
 /etc/init.d/x11-common start

--- a/app/tiger.sh
+++ b/app/tiger.sh
@@ -17,7 +17,7 @@ if [ -n "${VNCPASS}" ]; then
 fi
 
 if [ -n "${USER}" ]; then
-  chown -R ${USER}.${USER} ${HOME}
+  chown -R ${USER}.${GROUP} ${HOME}
   SUDOUSEROPTION="-u ${USER}"
 fi
 

--- a/conf/xstartup
+++ b/conf/xstartup
@@ -1,3 +1,4 @@
-#!/bin/bash                     
-                                
+#!/bin/bash
+
+exec /usr/bin/vncconfig -nowin &
 exec /usr/bin/openbox-session


### PR DESCRIPTION
I added two environment variables to let the user define custom group name and group-id for non-root user.

And in my case I need the file permissions written to some volumes to be writable by `group` so I added an option to set `umask`.

I also delete some temp files from vnc server, because the vnc server was not reachable after `docker restart  ubuntu-desktop`.